### PR TITLE
Handle omitted exit code correctly

### DIFF
--- a/lib/src/number_parser/parsers/_international_prefix_parser.dart
+++ b/lib/src/number_parser/parsers/_international_prefix_parser.dart
@@ -5,22 +5,25 @@ abstract class InternationalPrefixParser {
   ///
   ///  It expects a normalized [phoneNumber].
   ///  if phone starts with + it is removed
-  static String removeExitCode(
+  static (String, bool) removeExitCode(
     String phoneNumber, {
     PhoneMetadata? callerCountryMetadata,
     PhoneMetadata? destinationCountryMetadata,
   }) {
     if (phoneNumber.startsWith('+')) {
-      return phoneNumber.substring(1);
+      return (phoneNumber.substring(1), true);
     }
 
     // if the caller country was provided it's easy, just remove the exit code
     // from the phone number
     if (callerCountryMetadata != null) {
-      return _removeExitCodeWithMetadata(phoneNumber, callerCountryMetadata);
+      return (
+        _removeExitCodeWithMetadata(phoneNumber, callerCountryMetadata),
+        true
+      );
     }
 
-    return phoneNumber;
+    return (phoneNumber, false);
   }
 
   static String _removeExitCodeWithMetadata(

--- a/lib/src/number_parser/parsers/phone_parser.dart
+++ b/lib/src/number_parser/parsers/phone_parser.dart
@@ -45,12 +45,12 @@ abstract class PhoneParser {
         ? MetadataFinder.getMetadataForIsoCode(destinationCountry)
         : null;
 
-    final withoutExitCode = InternationalPrefixParser.removeExitCode(
+    final (withoutExitCode, containsExitCode) =
+        InternationalPrefixParser.removeExitCode(
       phoneNumber,
       destinationCountryMetadata: destinationMetadata,
       callerCountryMetadata: callerMetadata,
     );
-    final containsExitCode = withoutExitCode.length != phoneNumber.length;
     // if no destination metadata was provided we have to find it,
     destinationMetadata ??= _findDestinationMetadata(
       phoneWithoutExitCode: withoutExitCode,
@@ -58,7 +58,9 @@ abstract class PhoneParser {
     );
     var national = withoutExitCode;
     // if there was no exit code then we assume we are dealing with a national number
-    if (containsExitCode) {
+    // if the number starts with the country code, we remove the country code
+    if (containsExitCode ||
+        withoutExitCode.startsWith(destinationMetadata.countryCode)) {
       national = CountryCodeParser.removeCountryCode(
         withoutExitCode,
         destinationMetadata.countryCode,


### PR DESCRIPTION
Hey there ✌🏻,
I stumbled upon this issue in my application, because supabase auth omits the `exitCode`. This resulted in the number being incorrectly displayed when being parsed by the `PhoneController`.

To reproduce this give the `PhoneInput` in the example app a `controller` with a default value like this (notice the omitted `+`):
```
final number = '4917612345678';
...
PhoneInput(
   controller: PhoneController(PhoneNumber.parse(number)),
   ...
   ),
```
This will result in the `PhoneInput` showing the correct countryCode but not removing the `countryCode` from the `nsn`. Effectively showing the user this faulty output:
<img width="233" alt="Screenshot 2024-04-29 at 13 55 55" src="https://github.com/LanarsInc/phone_input/assets/58365599/99671855-0cd6-496f-bf80-5cc23c086cb8">

Instead of the correct number:
<img width="212" alt="Screenshot 2024-04-29 at 13 55 26" src="https://github.com/LanarsInc/phone_input/assets/58365599/d02df9d7-a789-4914-a8fc-0dfbaa27aa3d">

Thanks for building the package though, handling phone numbers is always a great pain which this package helped me with, a lot! 👍🏻